### PR TITLE
Change reference from jade to pod

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -2,10 +2,10 @@
 var path = require('path'),
   fs = require('fs'),
   markdown = require('markdown'),
-  jade = require('jade');
+  pod = require('pod');
 
 
-var TMPL_FILE = path.join(__dirname, './tmpl.jade');
+var TMPL_FILE = path.join(__dirname, './tmpl.pod');
 var template;
 
 var styles = [
@@ -16,7 +16,7 @@ var scripts = [];
 
 function compileTemplate(opts) {
   var tmplstr = fs.readFileSync(TMPL_FILE, 'utf-8');
-  template = jade.compile(tmplstr, opts);
+  template = pod.compile(tmplstr, opts);
 }
 
 // make static html page

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "commander": "~1.1.1",
-    "jade": "~0.28.2",
+    "pod": "~0.9.0",
     "markdown": "~0.4.0"
   }
 }


### PR DESCRIPTION
We cannot continue to use jade. This project has been renamed pod. 
